### PR TITLE
Fix 405 Method Not Allowed error on root endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -279,7 +279,9 @@ async def publish_receipt_event(receipt: ProcessedReceipt):
 
 @app.get("/")
 @app.head("/")
+@app.post("/")
 def root():
+    logger.info("🏠 Root endpoint accessed")
     return {"status": "ok", "service": "fintech-etl"}
 
 @app.get("/health")


### PR DESCRIPTION
- Add POST method support to root endpoint
- Add logging to root endpoint for debugging
- Resolves Cloud Run health check POST requests