### PR TITLE
Fix webhook async/await issue in intake handler

### DIFF
--- a/intake/handlers.py
+++ b/intake/handlers.py
@@ -74,7 +74,10 @@ async def ingest_csv_handler(
 
     # Process CSV directly from memory (no GCS download needed)
     if background_tasks and process_csv_direct_func:
-        background_tasks.add_task(process_csv_direct_func, contents, object_name, gcs_bucket, google_drive_url)
+        # Create a wrapper function that properly awaits the async function
+        async def process_wrapper():
+            await process_csv_direct_func(contents, object_name, gcs_bucket, google_drive_url)
+        background_tasks.add_task(process_wrapper)
 
     return {
         "status": "success",


### PR DESCRIPTION
- Fix RuntimeWarning: coroutine 'process_csv_from_bytes' was never awaited
- Add proper async wrapper function for background task processing
- Ensure webhook payloads are sent to Make.com correctly
- Resolves issue where webhooks were not being triggered